### PR TITLE
Typo: Replaces <success> with <info> and extra nl since no such tag exist

### DIFF
--- a/app/Commands/Host.php
+++ b/app/Commands/Host.php
@@ -232,7 +232,8 @@ class Host extends Command
         $this->outputInterface->writeln('<info>Provisioning Vagrant...</info>');
         $this->provisionHomestead();
 
-        $this->outputInterface->writeln('<success>Complete! Visit: http://'.$this->domain.'</success>');
+        $this->outputInterface->writeln('');
+        $this->outputInterface->writeln('<info>Complete! Visit: http://'.$this->domain.'</info>');
     }
 
     private function defaultDatabaseNameFromKey($key){


### PR DESCRIPTION
I couldn't find such tag from Symfony documentation so it probably just doesn't exist (it also prints raw tag)
Adding extra newline to make text stand up more since its now using same color as previous lines